### PR TITLE
Include the right source directory for Wayland/CMake

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -235,7 +235,7 @@ if (USE_X11)
   )
 
 elseif (OPTION_USE_WAYLAND)
-  set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -I${CMAKE_BINARY_DIR}/src")
+  set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -I${CMAKE_CURRENT_BINARY_DIR}")
   set (DRIVER_FILES
     drivers/Posix/Fl_Posix_System_Driver.cxx
     drivers/Posix/Fl_Posix_Printer_Driver.cxx
@@ -481,7 +481,7 @@ if (USE_X11)
 endif (USE_X11)
 
 if (OPTION_USE_WAYLAND)
-  set (CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -I. -I${CMAKE_CURRENT_SOURCE_DIR}/../libdecor/src -fPIC -D_GNU_SOURCE -DLIBDECOR_PLUGIN_API_VERSION=1 -DLIBDECOR_PLUGIN_DIR=\\\"Unused\\\" ")
+  set (CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -I${CMAKE_CURRENT_BINARY_DIR} -I${CMAKE_CURRENT_SOURCE_DIR}/../libdecor/src -fPIC -D_GNU_SOURCE -DLIBDECOR_PLUGIN_API_VERSION=1 -DLIBDECOR_PLUGIN_DIR=\\\"Unused\\\" ")
   list (APPEND CFILES
     xutf8/keysym2Ucs.c
     scandir_posix.c


### PR DESCRIPTION
While experimenting with `fltk-rs` and your wayland branch I've faced an issue with missing xdg-* includes while trying to build it.

We should include the right dir containing autogenerated source files, otherwise building project with fltk added by `add_subdirectory` will fail.

Here is a minimal example: https://github.com/polter-rnd/fltk-test/
Try to build it somehow like this:
```
git clone --recursive https://github.com/polter-rnd/fltk-test.git
cd fltk-test
mkdir -p build
cd build
cmake .. -DOPTION_USE_WAYLAND=1
cmake --build .
```

Here is what you will get:
```
fltk-test/lib/fltk/src/drivers/Wayland/Fl_Wayland_Screen_Driver.cxx:23:10: fatal error: xdg-shell-client-protocol.h: No such file or directory
   23 | #include "xdg-shell-client-protocol.h"
      |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~
compilation terminated.
gmake[2]: *** [lib/fltk/src/CMakeFiles/fltk.dir/build.make:2164: lib/fltk/src/CMakeFiles/fltk.dir/drivers/Wayland/Fl_Wayland_Screen_Driver.cxx.o] Error 1
gmake[1]: *** [CMakeFiles/Makefile2:464: lib/fltk/src/CMakeFiles/fltk.dir/all] Error 2
```